### PR TITLE
Rework the sent ack via mqtt logic

### DIFF
--- a/firmware/lib/SiedleClient/SiedleClient.cpp
+++ b/firmware/lib/SiedleClient/SiedleClient.cpp
@@ -107,7 +107,7 @@ void SiedleClient::bitTimerISR() {
             if (bitNumber >= 0) {
                 auto bit = bitRead(cmd_tx_buf, bitNumber--);
                 digitalWrite(outputPin, !bit);
-            } else {
+            } else { // bitNumber < 0
                 digitalWrite(outputPin, LOW);
                 digitalWrite(outputCarrierPin, LOW);
 

--- a/firmware/src/siedle-service.h
+++ b/firmware/src/siedle-service.h
@@ -46,6 +46,8 @@ public:
 private:
     CircularBuffer<siedle_cmd_t, SIEDLE_TX_QUEUE_LEN> siedleTxQueue;
     unsigned long lastTxMillis;
+    unsigned int lastTxCounter;
+    siedle_cmd_t lastTxCmd;
 };
 
 extern SiedleServiceClass SiedleService;


### PR DESCRIPTION
Do not send the cmd to mqtt to the sent topic if the siedle client has not increased the tx counter (handle the error case here)