### PR TITLE
Use 256dpi/MQTT library

### DIFF
--- a/firmware/include/settings.h
+++ b/firmware/include/settings.h
@@ -34,3 +34,6 @@
 // #define USE_DEBUG_SERIAL_CONSOLE
 
 #endif //FIRMWARE_SETTINGS_H
+
+// MQTT buffer size in bytes
+#define MQTT_BUF_SIZE 256

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -20,7 +20,7 @@ lib_deps =
 	rlogiacco/CircularBuffer@^1.3.3
 	arduino-libraries/RTCZero@^1.6.0
 	arduino-libraries/ArduinoECCX08
-	knolleary/PubSubClient@^2.8.0
+	256dpi/MQTT@^2.5.1
 	arduino-libraries/ArduinoBearSSL@^1.7.3
 	javos65/WDTZero@^1.3.0
 extra_scripts = 
@@ -40,5 +40,5 @@ board = d1_mini
 lib_deps = 
 	CircularBuffer
 	NTPClient
-	knolleary/PubSubClient@^2.8.0
+	256dpi/MQTT@^2.5.1
 build_flags = '-DMDNS_HOSTNAME="siedle"'

--- a/firmware/src/mqtt-service.cpp
+++ b/firmware/src/mqtt-service.cpp
@@ -60,7 +60,7 @@ void MQTTServiceClass::begin() {
     // Set the ECCX08 slot to use for the private key
     // and the accompanying public certificate for it
     sslClient.setEccSlot(0, certificate);
-    mqttClient.begin(broker, sslClient);
+    mqttClient.begin(broker, 8883, sslClient);
 
     #elif defined(ESP8266)
     loadSSLConfiguration();

--- a/firmware/src/mqtt-service.cpp
+++ b/firmware/src/mqtt-service.cpp
@@ -61,7 +61,6 @@ void MQTTServiceClass::begin() {
     // and the accompanying public certificate for it
     sslClient.setEccSlot(0, certificate);
     mqttClient.begin(broker, sslClient);
-    mqttClient.setTimeout(10);
 
     #elif defined(ESP8266)
     loadSSLConfiguration();

--- a/firmware/src/mqtt-service.cpp
+++ b/firmware/src/mqtt-service.cpp
@@ -28,24 +28,20 @@ const char broker[]      = SECRET_BROKER;
 const char* certificate  = SECRET_CERTIFICATE;
 #endif
 
-void MQTTServiceClass::onMessageReceived(char* topic, byte* payload, unsigned int length) {
-    char *cmdString = (char*)malloc(length + 1);
-    memcpy(cmdString, payload, length);
-    cmdString[length] = 0; // null termination
-    uint32_t cmd = atol(cmdString);
-    free (cmdString);
+void MQTTServiceClass::onMessageReceived(String &topic, String &payload) {
+    uint32_t cmd = atol(payload.c_str());
     SiedleService.transmitAsync(cmd);
     rxCount++;
 }
 
-void _onMessageReceivedWrapper(char* topic, byte* payload, unsigned int length) {
-    MQTTService.onMessageReceived(topic, payload, length);
+void _onMessageReceivedWrapper(String &topic, String &payload) {
+    MQTTService.onMessageReceived(topic, payload);
 }
 
 #ifdef ARDUINO_ARCH_SAMD
-MQTTServiceClass::MQTTServiceClass() : mqttTxQueue(), wifiClient(), sslClient(wifiClient), mqttClient(sslClient) { }
+MQTTServiceClass::MQTTServiceClass() : mqttTxQueue(), wifiClient(), sslClient(wifiClient), mqttClient(MQTT_BUF_SIZE) { }
 #elif defined(ESP8266)
-MQTTServiceClass::MQTTServiceClass() : mqttTxQueue(), sslClient(), mqttClient(SECRET_BROKER, 8883, sslClient) { }
+MQTTServiceClass::MQTTServiceClass() : mqttTxQueue(), sslClient(), mqttClient(MQTT_BUF_SIZE) { }
 #endif
 
 void MQTTServiceClass::begin() {
@@ -64,10 +60,8 @@ void MQTTServiceClass::begin() {
     // Set the ECCX08 slot to use for the private key
     // and the accompanying public certificate for it
     sslClient.setEccSlot(0, certificate);
-    mqttClient.setServer(broker, 8883);
-
-    // bail out after 10 seconds to avoid issues with the hardware watchdog
-    mqttClient.setSocketTimeout(MQTT_TIMEOUT_SEC);
+    mqttClient.begin(broker, sslClient);
+    mqttClient.setTimeout(10);
 
     #elif defined(ESP8266)
     loadSSLConfiguration();
@@ -79,7 +73,7 @@ void MQTTServiceClass::begin() {
     // a client id for you based on the millis() value if not set
     //
     // mqttClient.setId("clientId");
-    mqttClient.setCallback(_onMessageReceivedWrapper);
+    mqttClient.onMessage(_onMessageReceivedWrapper);
 }
 
 #ifdef ESP8266

--- a/firmware/src/mqtt-service.cpp
+++ b/firmware/src/mqtt-service.cpp
@@ -157,16 +157,16 @@ void MQTTServiceClass::loop() {
                 + String(",\"cmd\":") + (unsigned long)entry.payload.cmd + "}";
 
             #ifdef ARDUINO_ARCH_SAMD
-            mqttClient.publish(entry.topic == received ? "siedle/received" : "siedle/sent", payload.c_str());
+            mqttClient.publish(entry.topic == received ? "siedle/received" : "siedle/sent", payload);
             txCount++;
             lastTxMillis = millis();
             #elif defined(ESP8266)
             switch (entry.topic) {
                 case received:
-                    mqttClient.publish(String(F("siedle/received")).c_str(), payload.c_str());
+                    mqttClient.publish(F("siedle/received"), payload);
                     break;
                 case sent:
-                    mqttClient.publish(String(F("siedle/sent")).c_str(), payload.c_str());
+                    mqttClient.publish(F("siedle/sent"), payload);
                     break;
             }
             #endif

--- a/firmware/src/mqtt-service.h
+++ b/firmware/src/mqtt-service.h
@@ -17,7 +17,7 @@
 #include <ESP8266WiFi.h>
 #endif
 
-#include <PubSubClient.h>
+#include <MQTTClient.h>
 
 enum MQTTTopic {
     received = 0,
@@ -61,7 +61,7 @@ public:
     }
     bool isConnected();
     MQTTState state;
-    void onMessageReceived(char* topic, byte* payload, unsigned int length);
+    void onMessageReceived(String &topic, String &payload);
 
 private:
     unsigned long reconnectAttemptMillis;
@@ -75,7 +75,7 @@ private:
     WiFiClientSecure sslClient;
     void loadSSLConfiguration();
     #endif
-    PubSubClient  mqttClient;
+    MQTTClient  mqttClient;
 };
 
 extern MQTTServiceClass MQTTService;


### PR DESCRIPTION
This refactor the codebase to use the 256dpi/MQTT library instead of the PubSubClient library, mainly to see if this solves the reboot issues