### PR TITLE
Refactor the webserver request parsing to save memory

### DIFF
--- a/firmware/lib/WebServer/WebServer.cpp
+++ b/firmware/lib/WebServer/WebServer.cpp
@@ -66,7 +66,7 @@ void WebServer::loop() {
 
                 // if the current line is blank, you got two newline characters in a row.
                 // that's the end of the client HTTP request, so send a response:
-                if (currentLineLength > 0) {
+                if (currentLineLength == 0) {
                     // HTTP headers always start with a response code (e.g. HTTP/1.1 200 OK)
                     // and a content-type so the client knows what's coming, then a blank line:
                     client.println("HTTP/1.1 200 OK");


### PR DESCRIPTION
we do not really need the request header at all, so rework the logic
to save memory on our quite constrained device.