### PR TITLE
Tweak watchdog settings

### DIFF
--- a/firmware/include/settings.h
+++ b/firmware/include/settings.h
@@ -35,5 +35,8 @@
 
 #endif //FIRMWARE_SETTINGS_H
 
+// Watchdog Settings
+#define WATCHDOG_SETUP WDT_HARDCYCLE16S
+
 // MQTT buffer size in bytes
 #define MQTT_BUF_SIZE 256

--- a/firmware/include/settings.h
+++ b/firmware/include/settings.h
@@ -36,7 +36,9 @@
 #endif //FIRMWARE_SETTINGS_H
 
 // Watchdog Settings
-#define WATCHDOG_SETUP WDT_HARDCYCLE16S
+// use a 32 seconds (soft) watchdog timeout
+// we do need this quite log timeout because the MQTT reconnects take sometime about 15 seconds to complete
+#define WATCHDOG_SETUP WDT_SOFTCYCLE32S
 
 // MQTT buffer size in bytes
 #define MQTT_BUF_SIZE 256

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -48,7 +48,7 @@ void __unused setup() {
     webServer.rootPageHandler = webUIHTMLHandler;
     webServer.begin();
 #ifdef ARDUINO_ARCH_SAMD
-    Watchdog.setup(WDT_HARDCYCLE16S);
+    Watchdog.setup(WATCHDOG_SETUP);
 #endif
 
 }


### PR DESCRIPTION
Set the watchdog timer to 32s to avoid issues when MQTT reconnects take longer than 15s